### PR TITLE
Scroll handler fix

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,6 @@ class Video {
 			window.scrollY >= Video1.parent.offsetTop && window.scrollY <= (Video1.parent.offsetTop + Video1.parent.offsetHeight - window.innerHeight)
 		) {
 			this.video.currentTime = this.video.duration * window.scrollY / this.parent.clientHeight;
-			window.requestAnimationFrame(this.scroll);
 		}
 	}
 	fullWidthOrHeight() {
@@ -34,7 +33,7 @@ let Video1 = new Video(videoEl,document.querySelector('.container'));
 Video1.fullWidthOrHeight();
 
 window.addEventListener('scroll', () => {
-	Video1.scroll();
+	window.requestAnimationFrame(() => Video1.scroll());
 });
 
 window.addEventListener('resize', () => {


### PR DESCRIPTION
Instead of starting a rAF loop inside the scroll handler, we call the scroll handler on every scroll event and throttle it using rAF.